### PR TITLE
Deprecate methods

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -4,5 +4,12 @@ import { name as appName } from './app.json';
 import { NOTIFLY_PROJECT_ID, NOTIFLY_USERNAME, NOTIFLY_PASSWORD } from '@env';
 import notifly from 'notifly-sdk';
 
-notifly.initialize(NOTIFLY_PROJECT_ID, NOTIFLY_USERNAME, NOTIFLY_PASSWORD);
+notifly.initialize(
+  NOTIFLY_PROJECT_ID,
+  NOTIFLY_USERNAME,
+  NOTIFLY_PASSWORD,
+  false
+);
+// deprecated method call test
+notifly.setNotiflyBackgroundMessageHandler();
 AppRegistry.registerComponent(appName, () => App);

--- a/src/NativeNotiflySdk.ts
+++ b/src/NativeNotiflySdk.ts
@@ -7,7 +7,8 @@ export interface Spec extends TurboModule {
   initialize(
     projectId: string,
     username: string,
-    password: string
+    password: string,
+    useCustomClickHandler: boolean | undefined
   ): Promise<void>;
   setUserId(userId: string | undefined): Promise<void>;
   setUserProperties(userProperties: UserProperties): Promise<void>;
@@ -17,6 +18,8 @@ export interface Spec extends TurboModule {
     segmentation_event_param_keys: string[] | undefined | null,
     isInternalEvent: boolean
   ): Promise<void>;
+  notiflyBackgroundHandler(_remoteMessage: any): Promise<void>;
+  setNotificationOpenedHandler(): Promise<void>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('NotiflySdk');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,8 +32,15 @@ export function multiply(a: number, b: number): Promise<number> {
 export function initialize(
   projectId: string,
   username: string,
-  password: string
+  password: string,
+  useCustomClickHandler: boolean | undefined = undefined
 ): Promise<void> {
+  // @deprecated useCustomClickHandler is deprecated since version 2.3.0
+  if (typeof useCustomClickHandler !== 'undefined') {
+    console.warn(
+      'Warning: useCustomClickHandler of notifly.initialize is deprecated and will be removed in the next major release.'
+    );
+  }
   return NotiflySdk.initialize(projectId, username, password);
 }
 
@@ -59,11 +66,33 @@ export function trackEvent(
   );
 }
 
+/**
+ * @deprecated Since version 2.3.0.
+ */
+export function notiflyBackgroundHandler(_remoteMessage: any): Promise<void> {
+  console.warn(
+    'Warning: notifly.notiflyBackgroundHandler(remoteMessage) is deprecated and will be removed in the next major release. You do not need to call this method anymore. remoteMessage is now handled automatically.'
+  );
+  return Promise.resolve();
+}
+
+/**
+ * @deprecated Since version 2.3.0.
+ */
+export function setNotiflyBackgroundMessageHandler(): Promise<void> {
+  console.warn(
+    'Warning: notifly.setNotiflyBackgroundMessageHandler() is deprecated and will be removed in the next major release. You do not need to call this method anymore. remoteMessage is now handled automatically.'
+  );
+  return Promise.resolve();
+}
+
 const notifly = {
   initialize,
   setUserId,
   setUserProperties,
   trackEvent,
+  notiflyBackgroundHandler,
+  setNotiflyBackgroundMessageHandler,
 };
 
 export default notifly;


### PR DESCRIPTION
## Summary

이제 모든 handler들이 native에서 자동으로 처리되거나 충돌이 방지되기 때문에 다음 3가지를 모두 deprecate합니다. 

- setNotiflyBackgroundMessageHandler()
- notiflyBackgroundHandler()
- initialize의 useCustomClickHandler

[현재 rn docs](https://docs.notifly.tech/ko/developer-guide/client-sdk/react-native-sdk) 참고해 주세요.

테스트:

![Screen Shot 2023-05-23 at 9 22 41 AM](https://github.com/team-michael/notifly-react-native-sdk/assets/13911240/ff41df7b-fc79-4258-bcb3-be24bbc5439d)
