### PR TITLE
null initialization - notifly ios

### DIFF
--- a/ios/NotiflySdk.mm
+++ b/ios/NotiflySdk.mm
@@ -15,6 +15,25 @@ RCT_REMAP_METHOD(multiply,
     resolve(result);
 }
 
+RCT_REMAP_METHOD(initialize,
+                 initializeWithProjectId:(NSString *)projectId 
+                 username:(NSString *)username 
+                 password:(NSString *)password 
+                 withResolver:(RCTPromiseResolveBlock)resolve 
+                 withRejecter:(RCTPromiseRejectBlock)reject)
+{
+    // Currently these parameters are not used
+    // NSString *projectId = projectId;
+    // NSString *username = username;
+    // NSString *password = password;
+
+    NSLog(@"[NotiflySdk] initializeWithProjectId: %@, username: %@, password: %@", projectId, username, password);
+    // TODO(Notifly): Implement this method
+
+    // Resolve the promise without any value
+    resolve(nil);
+}
+
 // Don't compile this code when we build for the old architecture.
 #ifdef RCT_NEW_ARCH_ENABLED
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:

--- a/notifly-sdk.podspec
+++ b/notifly-sdk.podspec
@@ -31,5 +31,6 @@ Pod::Spec.new do |s|
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"
+    s.dependency "notifly_sdk" ~> "1.0.6"
   end
 end


### PR DESCRIPTION
notifly-sdk pod을 설치합니다.

objective-c 로 해야하는 부분이 있어서 여기서 hold했습니다. 

flarelane 참고
ios sdk: https://github.com/flarelane/FlareLane-iOS-SDK/blob/ef029db1f5ddeb5bfa11d8b77d07d6924ca08873/FlareLane/Classes/FlareLane.swift#L11
RN: https://www.npmjs.com/package/@flarelane/react-native-sdk?activeTab=code