### PR TITLE
Set SDK type and version for android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -88,7 +88,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.github.team-michael:notifly-android-sdk:1.0.1"
+  implementation "com.github.team-michael:notifly-android-sdk:1.0.3"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/src/main/java/com/notiflysdk/NotiflySdkModule.kt
+++ b/android/src/main/java/com/notiflysdk/NotiflySdkModule.kt
@@ -7,7 +7,10 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.Promise
 import tech.notifly.Notifly
+import tech.notifly.utils.NotiflyControlToken
+import tech.notifly.utils.NotiflySdkType
 
+class NotiflyControlTokenImpl : NotiflyControlToken
 class NotiflySdkModule internal constructor(private val reactContext: ReactApplicationContext) :
   NotiflySdkSpec(reactContext) {
 
@@ -26,6 +29,8 @@ class NotiflySdkModule internal constructor(private val reactContext: ReactAppli
   override fun initialize(projectId: String, username: String, password: String, promise: Promise) {
     try {
       Log.d("NotiflySdkModule", "Notifly initialize call")
+      Notifly.setSdkType(NotiflyControlTokenImpl(), NotiflySdkType.REACT_NATIVE)
+      Notifly.setSdkVersion(NotiflyControlTokenImpl(), "2.3.0-beta.1") // TODO: get version from package.json
       Notifly.initialize(reactContext, projectId, username, password)
       promise.resolve(null)
     } catch (e: Exception) {


### PR DESCRIPTION
sdk_type과 sdk_version을 android에 대해 override합니다.

참고:
https://github.com/team-michael/notifly-android-sdk/pull/74
https://github.com/team-michael/notifly_flutter/pull/6

테스트

![Screen Shot 2023-05-25 at 8 52 18 AM](https://github.com/team-michael/notifly-react-native-sdk/assets/13911240/0581caf2-3de5-4fa9-b7de-c37d13bbe4d5)
