### PR TITLE
chore: update release workflow to use OIDC-based npm publishing

### DIFF
--- a/.github/workflows/generate-llms.yml
+++ b/.github/workflows/generate-llms.yml
@@ -1,19 +1,19 @@
-name: Generate CLIX React Native LLMS
+name: Generate LLMS
 
 on:
   workflow_dispatch:
     inputs:
       llm_mode:
-        description: 'Generation mode'
+        description: "Generation mode"
         type: choice
         options: [changed, all]
         default: changed
       base:
-        description: 'Base ref/tag/sha for compare (optional)'
+        description: "Base ref/tag/sha for compare (optional)"
         type: string
         required: false
       head:
-        description: 'Head ref/tag/sha for compare (optional)'
+        description: "Head ref/tag/sha for compare (optional)"
         type: string
         required: false
   release:
@@ -140,9 +140,9 @@ jobs:
           script: |
             const defaultBranch = context.payload.repository.default_branch;
             const head = process.env.BRANCH;
-            const title = 'chore: update CLIX React Native LLMS index';
+            const title = 'chore: update LLMS index';
             const body = [
-              'This PR updates the generated CLIX React Native SDK LLMS index.',
+              'This PR updates the generated LLMS index.',
               '',
               `- Triggered by: ${context.eventName}`,
               `- Range: ${process.env.COMPARE || '(none / full)'}`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm
         run: npm install -g npm@11.5.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+      id-token: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -18,8 +22,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
-          registry-url: 'https://registry.npmjs.org/'
+          node-version: 22
 
       - name: Install dependencies
         run: npm ci
@@ -50,18 +53,10 @@ jobs:
       - name: Build package
         run: npm run build
 
-      - name: Publish beta version to npm
-        if: contains(github.event.inputs.version, 'beta')
+      - name: Publish to npm
         run: |
-          echo "Publishing to notifly-sdk as beta version..."
-          npm publish --tag beta
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish stable version to npm
-        if: ${{ !contains(github.event.inputs.version, 'beta') }}
-        run: |
-          echo "Publishing to notifly-sdk as stable version..."
-          npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          if [ "${{ contains(github.event.inputs.version, 'beta') }}" = "true" ]; then
+            npm publish --provenance --access public --tag beta
+          else
+            npm publish --provenance --access public
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           node-version: 22
 
+      - name: Upgrade npm
+        run: npm install -g npm@11.5.1
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary

Release workflow를 OIDC 기반 npm publishing으로 전환합니다. (`notifly-js-sdk` 참고)

## Describe your changes

- `permissions` 블록 추가 (`contents: write`, `id-token: write`) — OIDC 토큰 발급용
- `npm publish --provenance --access public` 적용 — npm provenance 서명
- `NODE_AUTH_TOKEN` 및 `registry-url` 제거 — OIDC 인증으로 대체
- Node.js 버전 18 → 22 업그레이드
- beta/stable publish 단계를 하나의 step으로 통합

> **Note**: npm 패키지 설정에서 이 GitHub repo를 trusted publisher로 등록해야 합니다.

## Issue ticket number and link

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Node.js를 18에서 22로 업그레이드했습니다.
  * 릴리스 워크플로 권한을 강화하고 권한/인증 처리 방식을 정리했습니다.
  * npm 업그레이드 단계와 버전 업데이트·체인절로그 확인·릴리스 생성 단계가 추가되어 배포 흐름이 개선되었습니다.
  * 배포가 베타인지 아닌지에 따라 자동으로 태그를 선택해 게시하도록 통합했습니다.
  * "Generate LLMS" 워크플로 이름과 관련 PR 제목/설명이 일반화되어 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->