### PR TITLE
chore: 4.0.4 - bump android sdk to 1.19.3 fixing dropped commands queued before initialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.4] - 2026-05-12
+
+### Fixed
+
+- Bump Android SDK to 1.19.3: fix pending commands remaining queued when `setUserId` is queued before `setUserProperties` on cold start.
+
 ## [4.0.3] - 2026-02-26
 
 ### Changed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -88,7 +88,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.github.team-michael:notifly-android-sdk:1.19.0"
+  implementation "com.github.team-michael:notifly-android-sdk:1.19.3"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/src/main/java/tech/notifly/rn/NotiflySdkModule.kt
+++ b/android/src/main/java/tech/notifly/rn/NotiflySdkModule.kt
@@ -37,7 +37,7 @@ class NotiflySdkModule internal constructor(private val reactContext: ReactAppli
       val context: Context = reactContext.currentActivity ?: reactContext.applicationContext
 
       Notifly.setSdkType(NotiflyControlTokenImpl(), NotiflySdkWrapperType.REACT_NATIVE)
-      Notifly.setSdkVersion(NotiflyControlTokenImpl(), "4.0.2")
+      Notifly.setSdkVersion(NotiflyControlTokenImpl(), "4.0.4")
 
       Notifly.initialize(context, projectId, username, password)
 

--- a/ios/NotiflySdk.swift
+++ b/ios/NotiflySdk.swift
@@ -9,7 +9,7 @@ class NotiflyReactNativeSdk: NSObject {
     reject _: RCTPromiseRejectBlock
   ) {
     Notifly.setSdkType(type: "react_native")
-    Notifly.setSdkVersion(version: "4.0.2")  // TODO: get version from package.json
+    Notifly.setSdkVersion(version: "4.0.4")  // TODO: get version from package.json
     Notifly.initialize(projectId: projectId, username: username, password: password)
     resolve(nil)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notifly-sdk",
-  "version": "4.0.2",
+  "version": "4.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "notifly-sdk",
-      "version": "4.0.2",
+      "version": "4.0.4",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/config-conventional": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifly-sdk",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Notifly SDK for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary

- Bumps Android SDK to **1.19.3** to pick up the `CommandDispatcher` queue fix from team-michael/notifly-android-sdk#172
- Fixes a cold-start race where a `setUserProperties` call queued right after `setUserId` (and before `initialize()` finished) could be silently dropped when storage already had the same `external_user_id`
- Bumps internal `setSdkVersion` strings in `NotiflySdkModule.kt` and `NotiflySdk.swift` (they had been left at `4.0.2` through the 4.0.3 release)
- Syncs `package-lock.json` to `4.0.4`

## Root cause (Android native SDK)

When `setUserId(sameId)` is queued before init and storage already holds the same external user id, `SetUserIdCommand.execute()` takes a fast path that skips `InAppMessageManager.refresh()` — the only side effect that would have transitioned the SDK to `REFRESHING`. The command then calls `setState(READY)` on a state that is already `READY`, which `NotiflySdkStateManager.setState` short-circuits as a no-op, so no listener fires and the pending queue never drains the next `SET_USER_PROPERTIES` command. The Android SDK fix (PR #172) makes `CommandDispatcher` itself transition to `REFRESHING` before executing a queued `SET_USER_ID`, so the final `setState(READY)` becomes a real transition that resumes the drain.

## Verification

Reproduced the buggy behavior on 1.16.1 (single `setUserId` + `setUserProperties` queued before `initialize`, storage primed with the same external user id from a prior session — same scenario customers hit):

```
NOT_INITIALIZED -> READY
Executing command: SET_USER_ID
Stop executing pending commands due to the recurring set user ID.
(no SET_USER_PROPERTIES execution)
```

After bumping to 1.19.3, the same scenario drains both commands:

```
NOT_INITIALIZED -> READY
READY -> REFRESHING                          ← new transition before queued SET_USER_ID
Executing command: SET_USER_ID
Stop executing pending commands due to the recurring set user ID.
REFRESHING -> READY                          ← end of SetUserIdCommand
Executing command: SET_USER_PROPERTIES       ← drain resumes, no drop
```

## Test plan

- [x] e2e on Android emulator (API 36) — confirmed `SET_USER_PROPERTIES` is drained after the fix
- [x] Reviewed Android SDK 1.19.3 changelog and unit test in team-michael/notifly-android-sdk#172
- [ ] Trigger Release workflow for `4.0.4` after merge to publish to npm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* Android SDK를 1.19.3으로 업데이트하여 앱 시작 시 pending commands가 큐에 남아있는 문제를 해결했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-michael/notifly-react-native-sdk/pull/60)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->