### PR TITLE
chore: 4.1.0 - bump native SDKs for real-time campaign sync via SSE channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - 2026-06-02
+
+### Changed
+
+- Bump Android SDK to 1.20.0: real-time campaign sync via SSE channel.
+- Bump iOS SDK to 2.5.0: real-time campaign sync via SSE channel.
+
 ## [4.0.4] - 2026-05-12
 
 ### Fixed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -88,7 +88,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.github.team-michael:notifly-android-sdk:1.19.3"
+  implementation "com.github.team-michael:notifly-android-sdk:1.20.0"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/src/main/java/tech/notifly/rn/NotiflySdkModule.kt
+++ b/android/src/main/java/tech/notifly/rn/NotiflySdkModule.kt
@@ -37,7 +37,7 @@ class NotiflySdkModule internal constructor(private val reactContext: ReactAppli
       val context: Context = reactContext.currentActivity ?: reactContext.applicationContext
 
       Notifly.setSdkType(NotiflyControlTokenImpl(), NotiflySdkWrapperType.REACT_NATIVE)
-      Notifly.setSdkVersion(NotiflyControlTokenImpl(), "4.0.4")
+      Notifly.setSdkVersion(NotiflyControlTokenImpl(), "4.1.0")
 
       Notifly.initialize(context, projectId, username, password)
 

--- a/ios/NotiflySdk.swift
+++ b/ios/NotiflySdk.swift
@@ -9,7 +9,7 @@ class NotiflyReactNativeSdk: NSObject {
     reject _: RCTPromiseRejectBlock
   ) {
     Notifly.setSdkType(type: "react_native")
-    Notifly.setSdkVersion(version: "4.0.4")  // TODO: get version from package.json
+    Notifly.setSdkVersion(version: "4.1.0")  // TODO: get version from package.json
     Notifly.initialize(projectId: projectId, username: username, password: password)
     resolve(nil)
   }

--- a/notifly_react_native_sdk.podspec
+++ b/notifly_react_native_sdk.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mmm,swift}"
 
-  s.dependency "notifly_sdk", "2.3.0"
+  s.dependency "notifly_sdk", "2.5.0"
   s.dependency "React-Core"
 
   # Don't install the dependencies when we run `pod install` in the old architecture.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notifly-sdk",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "notifly-sdk",
-      "version": "4.0.4",
+      "version": "4.1.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/config-conventional": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifly-sdk",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "Notifly SDK for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary

- Bump iOS Native SDK to **2.5.0** (real-time campaign sync via SSE channel)
- Bump Android Native SDK to **1.20.0** (real-time campaign sync via SSE channel)
- Bump RN SDK version to **4.1.0**

## Changes

- `notifly_react_native_sdk.podspec`: `notifly_sdk` 2.3.0 → 2.5.0
- `android/build.gradle`: `notifly-android-sdk` 1.19.3 → 1.20.0
- `package.json` + `package-lock.json` version 4.0.4 → 4.1.0
- `NotiflySdkModule.kt` / `NotiflySdk.swift` 의 `setSdkVersion` 문자열 동기화 (4.0.4 → 4.1.0)
- Add 4.1.0 CHANGELOG entry

## Test plan

- [ ] `npm install` succeeds with new lock
- [ ] Example app boots on iOS / Android with new native SDKs
- [ ] In-app message + push notification regression check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 실시간 캠페인 동기화 기능 추가 (SSE 채널 지원)

* **업데이트**
  * SDK 버전 4.1.0으로 업그레이드
  * Android SDK를 1.20.0으로 업데이트
  * iOS SDK를 2.5.0으로 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->