### PR TITLE
chore: 4.1.1 - bump iOS SDK to 2.5.1 (APNs→FCM token ordering race fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.1] - 2026-06-10
+
+### Fixed
+
+- Bump iOS SDK to 2.5.1: fix an APNs → FCM token acquisition ordering race on cold start where the FCM token could be requested before the APNs token was associated, registering a stale/unassociated token and driving repeated token re-acquisition.
+
 ## [4.1.0] - 2026-06-02
 
 ### Changed

--- a/android/src/main/java/tech/notifly/rn/NotiflySdkModule.kt
+++ b/android/src/main/java/tech/notifly/rn/NotiflySdkModule.kt
@@ -37,7 +37,7 @@ class NotiflySdkModule internal constructor(private val reactContext: ReactAppli
       val context: Context = reactContext.currentActivity ?: reactContext.applicationContext
 
       Notifly.setSdkType(NotiflyControlTokenImpl(), NotiflySdkWrapperType.REACT_NATIVE)
-      Notifly.setSdkVersion(NotiflyControlTokenImpl(), "4.1.0")
+      Notifly.setSdkVersion(NotiflyControlTokenImpl(), "4.1.1")
 
       Notifly.initialize(context, projectId, username, password)
 

--- a/ios/NotiflySdk.swift
+++ b/ios/NotiflySdk.swift
@@ -9,7 +9,7 @@ class NotiflyReactNativeSdk: NSObject {
     reject _: RCTPromiseRejectBlock
   ) {
     Notifly.setSdkType(type: "react_native")
-    Notifly.setSdkVersion(version: "4.1.0")  // TODO: get version from package.json
+    Notifly.setSdkVersion(version: "4.1.1")  // TODO: get version from package.json
     Notifly.initialize(projectId: projectId, username: username, password: password)
     resolve(nil)
   }

--- a/notifly_react_native_sdk.podspec
+++ b/notifly_react_native_sdk.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mmm,swift}"
 
-  s.dependency "notifly_sdk", "2.5.0"
+  s.dependency "notifly_sdk", "2.5.1"
   s.dependency "React-Core"
 
   # Don't install the dependencies when we run `pod install` in the old architecture.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notifly-sdk",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "notifly-sdk",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/config-conventional": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifly-sdk",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Notifly SDK for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Bumps the iOS native dependency to **notifly_sdk 2.5.1** and the RN SDK to **4.1.1**.

### Why
iOS SDK 2.5.1 fixes an APNs → FCM token acquisition ordering race on cold start: the FCM token could be requested before the APNs token was associated with Firebase Messaging, registering a stale/unassociated token and driving repeated token re-acquisition (observed as frequent `device_token` changes and FCM `UNREGISTERED`/404 on delivery).

### Changes
- `notifly_react_native_sdk.podspec`: `notifly_sdk` pin `2.5.0` → `2.5.1`
- `package.json` / `package-lock.json`: `4.1.0` → `4.1.1`
- `ios/NotiflySdk.swift`: `setSdkVersion("4.1.1")`
- `android/.../NotiflySdkModule.kt`: `setSdkVersion(..., "4.1.1")`
- `CHANGELOG.md`: 4.1.1 entry

Android native SDK is unchanged (this is an iOS-only fix); `notifly-android-sdk` stays at 1.20.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트 - 버전 4.1.1

* **Bug Fixes**
  * iOS SDK를 2.5.1로 업그레이드하여 콜드 스타트 시 발생하는 토큰 획득 순서 문제 수정

* **Chores**
  * SDK 버전을 4.1.1로 업데이트
  * iOS 의존성 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->