### PR TITLE
chore: 4.2.0 - bump native SDKs for ad push opt-out (수신거부)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.0] - 2026-06-15
+
+### Changed
+
+- Bump Android SDK to 1.21.0: ad push opt-out ("수신거부") area in expanded notifications.
+- Bump iOS SDK to 2.6.0: ad push opt-out ("수신거부") action on notification long-press.
+
 ## [4.1.1] - 2026-06-10
 
 ### Fixed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -88,7 +88,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.github.team-michael:notifly-android-sdk:1.20.0"
+  implementation "com.github.team-michael:notifly-android-sdk:1.21.0"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/src/main/java/tech/notifly/rn/NotiflySdkModule.kt
+++ b/android/src/main/java/tech/notifly/rn/NotiflySdkModule.kt
@@ -37,7 +37,7 @@ class NotiflySdkModule internal constructor(private val reactContext: ReactAppli
       val context: Context = reactContext.currentActivity ?: reactContext.applicationContext
 
       Notifly.setSdkType(NotiflyControlTokenImpl(), NotiflySdkWrapperType.REACT_NATIVE)
-      Notifly.setSdkVersion(NotiflyControlTokenImpl(), "4.1.1")
+      Notifly.setSdkVersion(NotiflyControlTokenImpl(), "4.2.0")
 
       Notifly.initialize(context, projectId, username, password)
 

--- a/ios/NotiflySdk.swift
+++ b/ios/NotiflySdk.swift
@@ -9,7 +9,7 @@ class NotiflyReactNativeSdk: NSObject {
     reject _: RCTPromiseRejectBlock
   ) {
     Notifly.setSdkType(type: "react_native")
-    Notifly.setSdkVersion(version: "4.1.1")  // TODO: get version from package.json
+    Notifly.setSdkVersion(version: "4.2.0")  // TODO: get version from package.json
     Notifly.initialize(projectId: projectId, username: username, password: password)
     resolve(nil)
   }

--- a/notifly_react_native_sdk.podspec
+++ b/notifly_react_native_sdk.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mmm,swift}"
 
-  s.dependency "notifly_sdk", "2.5.1"
+  s.dependency "notifly_sdk", "2.6.0"
   s.dependency "React-Core"
 
   # Don't install the dependencies when we run `pod install` in the old architecture.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notifly-sdk",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "notifly-sdk",
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/config-conventional": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifly-sdk",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "Notifly SDK for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## 4.2.0 — 광고 푸시 수신거부(opt-out)

네이티브 SDK를 광고 푸시 "수신거부" 기능 버전으로 올립니다. (래퍼 코드 변경 없음 — 네이티브 핀 + 버전 메타만)

### Changed
- Bump **Android SDK** to `1.21.0`: 펼침 알림에 "수신거부" 영역
- Bump **iOS SDK** to `2.6.0`: 알림 롱프레스 시 "수신거부" 액션

### 변경 파일 (기존 버전업 컨벤션과 동일)
- `package.json` / `package-lock.json` → 4.2.0
- `android/build.gradle` → notifly-android-sdk 1.21.0
- `notifly_react_native_sdk.podspec` → notifly_sdk 2.6.0
- `NotiflySdkModule.kt` / `NotiflySdk.swift` → setSdkVersion "4.2.0"
- `CHANGELOG.md`

> 사용법: 푸시 커스텀 데이터에 `unsubscribe_url` 추가 시 수신거부 노출/이동. (iOS는 서버가 `aps.category=NOTIFLY_AD` 동반 발송 필요)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * SDK 버전을 4.2.0으로 업데이트했습니다.
  * Android SDK 1.21.0, iOS SDK 2.6.0으로 업그레이드했습니다.
  * 확장 알림에서 광고 푸시 수신거부 동작이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->